### PR TITLE
Fix typo in startdate

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ language: "en"     # lowercase two-letter ISO language code such as "fr" (see ht
 latlng: "FIXME"       # decimal latitude and longitude of workshop venue (e.g., "41.7901128,-87.6007318" - use http://www.latlong.net/)
 humandate: "Feb 26-27, 2018"    # human-readable dates for the workshop (e.g., "Feb 17-18, 2020")
 humantime: "9:00 am - 4:00 pm"    # human-readable times for the workshop (e.g., "9:00 am - 4:30 pm")
-startdate: 2018-02-26E      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
+startdate: 2018-02-26      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
 enddate: 2018-02-27        # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
 instructor: ["Zena Lapp", "Scott Martin", "Marc Sze"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
 helper: ["Arthur Endsley", "Srihari Sundar", "Stephanie Thiede"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]


### PR DESCRIPTION
This workshop doesn't appear on [the workshops page](https://umswc.github.io/workshops/) due to a typo in the machine-readable `startdate`.